### PR TITLE
Fix nightly builds failing due to TFTrue master releases updating

### DIFF
--- a/packages/tf2-base/entrypoint.sh
+++ b/packages/tf2-base/entrypoint.sh
@@ -24,7 +24,7 @@ faketty() {
 
 quit() {
   echo "*** Stopping ***"
-  "${SERVER_DIR}/rcon" -H 127.0.0.1 -p ${PORT} -P ${RCON_PASSWORD} quit
+  "${SERVER_DIR}/rcon" -H ${IP/0.0.0.0/127.0.0.1} -p ${PORT} -P ${RCON_PASSWORD} quit
   sleep 5
   exit 0
 }

--- a/packages/tf2-base/healthcheck.sh
+++ b/packages/tf2-base/healthcheck.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-"${SERVER_DIR}/rcon" -H 127.0.0.1 -p ${PORT} -P ${RCON_PASSWORD} status
+"${SERVER_DIR}/rcon" -H ${IP/0.0.0.0/127.0.0.1} -p ${PORT} -P ${RCON_PASSWORD} status

--- a/packages/tf2-tftrue/Dockerfile
+++ b/packages/tf2-tftrue/Dockerfile
@@ -1,14 +1,17 @@
 FROM melkortf/tf2-sourcemod:latest
 LABEL maintainer="garrappachc@gmail.com"
 
-ARG TFTRUE_URL=https://github.com/AnAkkk/TFTrue/raw/public/release/TFTrue.so
+ARG TFTRUE_VERSION=4.85
+ARG TFTRUE_URL=https://github.com/AnAkkk/TFTrue/archive/refs/tags/${TFTRUE_VERSION}.zip
 
 COPY TFTrue.vdf "${SERVER_DIR}/tf/addons/TFTrue.vdf"
 COPY checksum.md5 .
-RUN wget -nv "${TFTRUE_URL}" -O TFTrue.so \
+RUN wget -nv "${TFTRUE_URL}" -O TFTrue.zip \
+  && unzip -p TFTrue.zip "TFTrue-${TFTRUE_VERSION}/release/TFTrue.so" > TFTrue.so \
   && md5sum -c checksum.md5 \
   && cp TFTrue.so "${SERVER_DIR}/tf/addons/TFTrue.so" \
-  && rm checksum.md5
+  && rm checksum.md5 \
+  && rm TFTrue.zip
 
 CMD ["+sv_pure", "2", "+map", "cp_badlands", "+maxplayers", "24"]
 

--- a/packages/tf2-tftrue/checksum.md5
+++ b/packages/tf2-tftrue/checksum.md5
@@ -1,1 +1,1 @@
-7894f30173c56ee9bf97f1bc9b7ed066  TFTrue.so
+6a5fc975f0086458ef601e37aaab84b5  TFTrue.so


### PR DESCRIPTION
I changed it to use the release page instead of using the repo release tab, this way nightly builds shouldn't fail and it can be manually adjusted to a newer version. I also use the -p option to not extract the whole source code of the TFTrue repo.