### PR TITLE
feat(tf2-base): update healthcheck

### DIFF
--- a/packages/tf2-base/healthcheck.sh
+++ b/packages/tf2-base/healthcheck.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-"${SERVER_DIR}/rcon" -H 127.0.0.1 -p ${PORT} -P ${RCON_PASSWORD} status
+"${SERVER_DIR}/rcon" -H ${IP/0.0.0.0/127.0.0.1} -p ${PORT} -P ${RCON_PASSWORD} status


### PR DESCRIPTION
Currently if you have a Server IP set the healthcheck will fail because the server is not listening on all interfaces. With this change it will only use 127.0.0.1 to healthcheck if no other Server IP is set, or it is 0.0.0.0.