### PR TITLE
fix(tf2-competitive): verify all plugins' checksums

### DIFF
--- a/packages/tf2-competitive/Dockerfile
+++ b/packages/tf2-competitive/Dockerfile
@@ -1,56 +1,54 @@
 FROM melkortf/tf2-tftrue:latest
 LABEL maintainer="garrappachc@gmail.com"
 
-RUN rm $SERVER_DIR/tf/addons/sourcemod/plugins/{nextmap,funcommands,funvotes}.smx
+COPY checksum.md5 .
 
-RUN wget -nv "https://github.com/spiretf/SOAP-TF2DM/archive/master.zip" -O "soap-dm.zip" \
-  && unzip "soap-dm.zip" \
-  && cp -r SOAP-TF2DM-master/* "${SERVER_DIR}/tf/" \
-  && rm -rf "SOAP-TF2DM-master" "soap-dm.zip"
+RUN rm "$SERVER_DIR/tf/addons/sourcemod/plugins/"{nextmap,funcommands,funvotes}.smx
 
-RUN DHOOKS_FILE_NAME="dhooks-2.2.0-detours16-sm110.zip" \
+RUN \
+  # download all the plugins
+  wget -nv "https://github.com/spiretf/SOAP-TF2DM/archive/master.zip" -O "soap-dm.zip" \
+  && DHOOKS_FILE_NAME="dhooks-2.2.0-detours16-sm110.zip" \
   && wget -nv "https://github.com/peace-maker/DHooks2/releases/download/v2.2.0-detours16/${DHOOKS_FILE_NAME}" \
-  && unzip "${DHOOKS_FILE_NAME}" -d "${SERVER_DIR}/tf/" \
-  && rm -f "${DHOOKS_FILE_NAME}"
-
-RUN COMP_FIXES_FILE_NAME="tf2-comp-fixes.zip" \
+  && COMP_FIXES_FILE_NAME="tf2-comp-fixes.zip" \
   && wget -nv "https://github.com/ldesgoui/tf2-comp-fixes/releases/download/v1.11.2/${COMP_FIXES_FILE_NAME}" \
-  && unzip -o "${COMP_FIXES_FILE_NAME}" -d "${SERVER_DIR}/tf/" \
-  && rm -f "${COMP_FIXES_FILE_NAME}"
-
-RUN UPDATED_PAUSE_PLUGIN_FILE_NAME="updated-pause-plugin.zip" \
+  && UPDATED_PAUSE_PLUGIN_FILE_NAME="updated-pause-plugin.zip" \
   && wget -nv "https://github.com/l-Aad-l/updated-pause-plugin/releases/download/v1.4.2/${UPDATED_PAUSE_PLUGIN_FILE_NAME}" \
-  && unzip -o "${UPDATED_PAUSE_PLUGIN_FILE_NAME}" -d "${SERVER_DIR}/tf/" \
-  && rm -f "${UPDATED_PAUSE_PLUGIN_FILE_NAME}"
-
-RUN wget -nv "https://github.com/sapphonie/MGEMod/archive/master.zip" -O "mgemod.zip" \
-  && unzip "mgemod.zip" \
-  && cp -r "MGEMod-master/addons" "${SERVER_DIR}/tf/" \
-  && rm -rf "MGEMod-master" "mgemod.zip"
-
-RUN CURL_FILE_NAME="curl_1.3.0.0.zip" \
+  && wget -nv "https://github.com/sapphonie/MGEMod/archive/master.zip" -O "mgemod.zip" \
+  && CURL_FILE_NAME="curl_1.3.0.0.zip" \
   && wget -nv "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/sourcemod-curl-extension/${CURL_FILE_NAME}" \
-  && unzip -o "${CURL_FILE_NAME}" -d "${SERVER_DIR}/tf/addons/sourcemod" \
-  && rm -f "${CURL_FILE_NAME}" \
-  && wget https://raw.githubusercontent.com/spiretf/docker-comp-server/master/curl.ext.so -O "${SERVER_DIR}/tf/addons/sourcemod/extensions/curl.ext.so"
-
-RUN wget -nv https://github.com/demostf/plugin/raw/master/demostf.smx -O $SERVER_DIR/tf/addons/sourcemod/plugins/demostf.smx
-
-RUN ETF2L_CONFIGS_FILE_NAME="etf2l_configs.zip" \
+  && ETF2L_CONFIGS_FILE_NAME="etf2l_configs.zip" \
   && wget -nv "http://etf2l.org/configs/${ETF2L_CONFIGS_FILE_NAME}" \ 
-  && unzip "${ETF2L_CONFIGS_FILE_NAME}" -d "${SERVER_DIR}/tf/cfg/" \
-  && rm -f "${ETF2L_CONFIGS_FILE_NAME}"
-
-RUN RGL_CONFIGS_FILE_NAME="rgl_configs.zip" \
-  && wget -nv "https://github.com/RGLgg/server-resources-updater/archive/master.zip" -O "${RGL_CONFIGS_FILE_NAME}" \ 
-  && unzip "${RGL_CONFIGS_FILE_NAME}" "server-resources-updater-master/cfg/*.cfg" \
-  && mv server-resources-updater-master/cfg/* "tf/cfg/" \
-  && rm -rf "${RGL_CONFIGS_FILE_NAME}" "server-resources-updater-master/"
-
-RUN wget -nv "https://github.com/dalegaard/srctvplus/releases/download/v1.1/srctvplus.so" -O "${SERVER_DIR}/tf/addons/srctvplus.so" \
-  && wget -nv "https://github.com/dalegaard/srctvplus/releases/download/v1.1/srctvplus.vdf" -O "${SERVER_DIR}/tf/addons/srctvplus.vdf"
-
-WORKDIR $SERVER_DIR
+  && RGL_CONFIGS_FILE_NAME="rgl_configs.zip" \
+  && wget -nv "https://github.com/RGLgg/server-resources-updater/archive/master.zip" -O "${RGL_CONFIGS_FILE_NAME}" \
+  && wget -nv "https://raw.githubusercontent.com/spiretf/docker-comp-server/master/curl.ext.so" \
+  && wget -nv "https://github.com/demostf/plugin/raw/master/demostf.smx" \
+  && wget -nv "https://github.com/dalegaard/srctvplus/releases/download/v1.1/srctvplus.so" \
+  && wget -nv "https://github.com/dalegaard/srctvplus/releases/download/v1.1/srctvplus.vdf" \
+  # verify md5 checksums
+  && md5sum -c checksum.md5 \
+  # install plugins
+  && unzip -q "soap-dm.zip" && cp -r SOAP-TF2DM-master/* "${SERVER_DIR}/tf/" \
+  && unzip -q "${DHOOKS_FILE_NAME}" -d "${SERVER_DIR}/tf/" \
+  && unzip -q -o "${COMP_FIXES_FILE_NAME}" -d "${SERVER_DIR}/tf/" \
+  && unzip -q -o "${UPDATED_PAUSE_PLUGIN_FILE_NAME}" -d "${SERVER_DIR}/tf/" \
+  && unzip -q "mgemod.zip" && cp -r "MGEMod-master/addons" "${SERVER_DIR}/tf/" \
+  && unzip -q -o "${CURL_FILE_NAME}" -d "${SERVER_DIR}/tf/addons/sourcemod" \
+  && unzip -q "${ETF2L_CONFIGS_FILE_NAME}" -d "${SERVER_DIR}/tf/cfg/" \
+  && unzip -q "${RGL_CONFIGS_FILE_NAME}" "server-resources-updater-master/cfg/*.cfg" && mv "server-resources-updater-master/cfg/"* "${SERVER_DIR}/tf/cfg/" \
+  && mv "curl.ext.so" "${SERVER_DIR}/tf/addons/sourcemod/extensions/curl.ext.so" \
+  && mv "demostf.smx" "${SERVER_DIR}/tf/addons/sourcemod/plugins/demostf.smx" \
+  && mv "srctvplus.so" "${SERVER_DIR}/tf/addons/srctvplus.so" \
+  && mv "srctvplus.vdf" "${SERVER_DIR}/tf/addons/srctvplus.vdf" \
+  # cleanup
+  && rm -r "SOAP-TF2DM-master" "soap-dm.zip" \
+  && rm -f "${DHOOKS_FILE_NAME}" \
+  && rm -f "${COMP_FIXES_FILE_NAME}" \
+  && rm -f "${UPDATED_PAUSE_PLUGIN_FILE_NAME}" \
+  && rm -r "MGEMod-master" "mgemod.zip" \
+  && rm -f "${CURL_FILE_NAME}" \
+  && rm -f "${ETF2L_CONFIGS_FILE_NAME}" \
+  && rm -r "${RGL_CONFIGS_FILE_NAME}" "server-resources-updater-master"
 
 ENV DEMOS_TF_APIKEY=
 

--- a/packages/tf2-competitive/Dockerfile
+++ b/packages/tf2-competitive/Dockerfile
@@ -42,13 +42,14 @@ RUN \
   && mv "srctvplus.vdf" "${SERVER_DIR}/tf/addons/srctvplus.vdf" \
   # cleanup
   && rm -r "SOAP-TF2DM-master" "soap-dm.zip" \
-  && rm -f "${DHOOKS_FILE_NAME}" \
-  && rm -f "${COMP_FIXES_FILE_NAME}" \
-  && rm -f "${UPDATED_PAUSE_PLUGIN_FILE_NAME}" \
+  && rm "${DHOOKS_FILE_NAME}" \
+  && rm "${COMP_FIXES_FILE_NAME}" \
+  && rm "${UPDATED_PAUSE_PLUGIN_FILE_NAME}" \
   && rm -r "MGEMod-master" "mgemod.zip" \
-  && rm -f "${CURL_FILE_NAME}" \
-  && rm -f "${ETF2L_CONFIGS_FILE_NAME}" \
-  && rm -r "${RGL_CONFIGS_FILE_NAME}" "server-resources-updater-master"
+  && rm "${CURL_FILE_NAME}" \
+  && rm "${ETF2L_CONFIGS_FILE_NAME}" \
+  && rm -r "${RGL_CONFIGS_FILE_NAME}" "server-resources-updater-master" \
+  && rm "checksum.md5"
 
 ENV DEMOS_TF_APIKEY=
 

--- a/packages/tf2-competitive/checksum.md5
+++ b/packages/tf2-competitive/checksum.md5
@@ -1,0 +1,12 @@
+7083db26e05ffcb1af52928709809f26  curl_1.3.0.0.zip
+011e7a2af1ad1f05b767113ff3709f0c  curl.ext.so
+4cf635206e979f12dbd60eb1afec839c  demostf.smx
+a1ba4ed343363f099dfa82c4e34538f0  dhooks-2.2.0-detours16-sm110.zip
+676e2e1c29b4e6fd42dac9bb54032f06  etf2l_configs.zip
+4fa177bc3c9fec76cbba10c51ea53d4e  mgemod.zip
+0d288c3b45211599c6633b2e3eddaa70  rgl_configs.zip
+abcdc4edf4ac677e8ca5ee8a3a9856d1  soap-dm.zip
+d132bd0706ab9088f19bb85e89be6ec8  srctvplus.so
+d68f0f5e420921e4a63fdcd62e6d1176  srctvplus.vdf
+d5b0192b164e46c091938aeeb57bb5f4  tf2-comp-fixes.zip
+046fe7d2cb239f207ddd8784a4a83faa  updated-pause-plugin.zip


### PR DESCRIPTION
Verify MD5 checksums of all downloaded plugins and configs.

Pros:
* limited possibility of malicious plugin download
* make it possible to version some downloads

Cons:
* each MD5 checksum has to be updated manually