### PR TITLE
feat(tf2-base): parse status command

### DIFF
--- a/packages/tf2-base/healthcheck.sh
+++ b/packages/tf2-base/healthcheck.sh
@@ -1,3 +1,18 @@
 #!/bin/bash
 
-"${SERVER_DIR}/rcon" -H ${IP/0.0.0.0/127.0.0.1} -p ${PORT} -P ${RCON_PASSWORD} status
+status="$("${SERVER_DIR}/rcon" -H ${IP/0.0.0.0/127.0.0.1} -p ${PORT} -P ${RCON_PASSWORD} status)" || exit $?
+
+# extract hostname
+if [[ $status =~ hostname:[[:space:]](.+)[[:space:]]version[[:space:]]:[[:space:]] ]]; then
+  echo "hostname: ${BASH_REMATCH[1]}"
+fi
+
+# extract map
+if [[ $status =~ map[[:space:]]+:[[:space:]]([a-zA-Z0-9_]+) ]]; then
+  echo "map: ${BASH_REMATCH[1]}"
+fi
+
+# extract player count
+if [[ $status =~ players[[:space:]]:[[:space:]]([0-9]+)[[:space:]]humans,[[:space:]][0-9]+[[:space:]]bots[[:space:]]\(([0-9]+)[[:space:]]max\) ]]; then
+  echo "players: ${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+fi


### PR DESCRIPTION
In the healthcheck.sh script, parse the output of the `status` rcon command in order to provide us with the relevant information: the hostname, current map and the number of online players.