### PR TITLE
feat(tf2-tftrue): build TFTrue in a Docker stage

### DIFF
--- a/packages/tf2-tftrue/Dockerfile
+++ b/packages/tf2-tftrue/Dockerfile
@@ -7,12 +7,12 @@ ARG TFTRUE_COMMIT=f5d866fcd5e6d27992b888919484a7b1a3f24454
 RUN apt-get -y update \
   && apt-get install -y build-essential git cmake gcc-multilib g++-multilib \
   && rm -rf /var/lib/apt/lists/* \
-  && git clone --recurse-submodules ${TFTRUE_REPOSITORY_URL} \
-  && cd TFTrue \
+  && git clone --recurse-submodules ${TFTRUE_REPOSITORY_URL} tftrue \
+  && cd tftrue \
   && git checkout ${TFTRUE_COMMIT} \
   && mkdir build \
   && cd build \
-  && cmake -E env CXXFLAGS="-DNO_AUTOUPDATE" cmake .. -DCMAKE_BUILD_TYPE=Release \
+  && env CXXFLAGS="-DNO_AUTOUPDATE" cmake .. -DCMAKE_BUILD_TYPE=Release \
   && make
 
 
@@ -20,7 +20,7 @@ FROM melkortf/tf2-sourcemod:latest
 LABEL maintainer="garrappachc@gmail.com"
 
 COPY TFTrue.vdf "${SERVER_DIR}/tf/addons/TFTrue.vdf"
-COPY --from=tftrue-build /build/TFTrue/build/TFTrue.so ${SERVER_DIR}/tf/addons/TFTrue.so
+COPY --from=tftrue-build /build/tftrue/build/TFTrue.so ${SERVER_DIR}/tf/addons/TFTrue.so
 
 CMD ["+sv_pure", "2", "+map", "cp_badlands", "+maxplayers", "24"]
 

--- a/packages/tf2-tftrue/Dockerfile
+++ b/packages/tf2-tftrue/Dockerfile
@@ -1,14 +1,26 @@
+FROM debian:latest AS tftrue-build
+WORKDIR /build
+
+ARG TFTRUE_REPOSITORY_URL=https://github.com/AnAkkk/TFTrue.git
+ARG TFTRUE_COMMIT=f5d866fcd5e6d27992b888919484a7b1a3f24454
+
+RUN apt-get -y update \
+  && apt-get install -y build-essential git cmake gcc-multilib g++-multilib \
+  && rm -rf /var/lib/apt/lists/* \
+  && git clone --recurse-submodules ${TFTRUE_REPOSITORY_URL} \
+  && cd TFTrue \
+  && git checkout ${TFTRUE_COMMIT} \
+  && mkdir build \
+  && cd build \
+  && cmake -E env CXXFLAGS="-DNO_AUTOUPDATE" cmake .. -DCMAKE_BUILD_TYPE=Release \
+  && make
+
+
 FROM melkortf/tf2-sourcemod:latest
 LABEL maintainer="garrappachc@gmail.com"
 
-ARG TFTRUE_URL=https://github.com/AnAkkk/TFTrue/raw/1867de3cf3dd77afdef6ee4c3929f6e94772cb35/release/TFTrue.so
-
 COPY TFTrue.vdf "${SERVER_DIR}/tf/addons/TFTrue.vdf"
-COPY checksum.md5 .
-RUN wget -nv "${TFTRUE_URL}" -O TFTrue.so \
-  && md5sum -c checksum.md5 \
-  && mv TFTrue.so "${SERVER_DIR}/tf/addons/TFTrue.so" \
-  && rm checksum.md5
+COPY --from=tftrue-build /build/TFTrue/build/TFTrue.so ${SERVER_DIR}/tf/addons/TFTrue.so
 
 CMD ["+sv_pure", "2", "+map", "cp_badlands", "+maxplayers", "24"]
 

--- a/packages/tf2-tftrue/checksum.md5
+++ b/packages/tf2-tftrue/checksum.md5
@@ -1,1 +1,0 @@
-7894f30173c56ee9bf97f1bc9b7ed066  TFTrue.so


### PR DESCRIPTION
Make tf2-tftrue build a multi-stage process that builds TFTrue.so from the source. That lets us control the build flags and have overall more control of what the binary looks like.