### PR TITLE
fix(tf2-competitive): update SrcTv+ checksum

### DIFF
--- a/packages/tf2-competitive/checksum.md5
+++ b/packages/tf2-competitive/checksum.md5
@@ -6,7 +6,7 @@ ab6cad7a51392a582fe8d66ddea77ccd  etf2l_configs.zip
 0c089b77ca11d7cc242b3f7785282599  mgemod.zip
 f04d86ea2f7f97ff344bd25d77669b70  server-resources-updater.zip
 b82f1184a9209e87251a03cfe9aa4221  soap.zip
-81c7baba37feaf602f0a64703f7e37bf  srctvplus.so
+0f310b2f1c0d05ef9c626e8848b79f49  srctvplus.so
 5576370d65439a86f4a2ec4c892d4221  srctvplus.vdf
 521fa89da1771fe54fe918433da3963f  tf2-comp-fixes.zip
 046fe7d2cb239f207ddd8784a4a83faa  updated-pause-plugin.zip


### PR DESCRIPTION
Apparently, re-uploading releases is an acceptable thing now...