### PR TITLE
fix(tf2-dm): add TFrue

### DIFF
--- a/packages/tf2-dm/Dockerfile
+++ b/packages/tf2-dm/Dockerfile
@@ -26,9 +26,13 @@ ARG AFK_MANAGER_PHRASES_URL=https://forums.alliedmods.net/attachment.php?attachm
 ARG SOURCEBANS_PLUGIN_FILE_NAME=sourcebans-pp-1.6.4.plugin-only.tar.gz
 ARG SOURCEBANS_PLUGIN_URL=https://github.com/sbpp/sourcebans-pp/releases/download/1.6.4/${SOURCEBANS_PLUGIN_FILE_NAME}
 
+ARG TF2RUE_PLUGIN_FILE_NAME=tf2rue.zip
+ARG TF2RUE_PLUGIN_VERSION=v0.0.4
+ARG TF2RUE_PLUGIN_URL=https://github.com/sapphonie/tf2rue/releases/download/${TF2RUE_PLUGIN_VERSION}/${TF2RUE_PLUGIN_FILE_NAME}
+
 RUN \
   # download plugins
-  wget -nv "${SOAP_DM_PLUGIN_URL}" "${DHOOKS_PLUGIN_URL}" "${COMP_FIXES_PLUGIN_URL}" "${SOURCEBANS_PLUGIN_URL}" \
+  wget -nv "${SOAP_DM_PLUGIN_URL}" "${DHOOKS_PLUGIN_URL}" "${COMP_FIXES_PLUGIN_URL}" "${SOURCEBANS_PLUGIN_URL}" "${TF2RUE_PLUGIN_URL}" \
   && wget -nv "${CLASS_RESTRICT_PLUGIN_URL}" -O "${CLASS_RESTRICT_PLUGIN_FILE_NAME}" \
   && wget -nv "${AFK_MANAGER_PLUGIN_URL}" -O "${AFK_MANAGER_PLUGIN_FILE_NAME}" \
   && wget -nv "${AFK_MANAGER_PHRASES_URL}" -O "${AFK_MANAGER_PHRASES_FILE_NAME}" \
@@ -38,12 +42,13 @@ RUN \
   && unzip -q "${SOAP_DM_PLUGIN_FILE_NAME}" -d "${SERVER_DIR}/tf/" \
   && unzip -q -o "${DHOOKS_PLUGIN_FILE_NAME}" -d "${SERVER_DIR}/tf/" \
   && unzip -q -o "${COMP_FIXES_PLUGIN_FILE_NAME}" -d "${SERVER_DIR}/tf/" \
+  && unzip -q -n "${TF2RUE_PLUGIN_FILE_NAME}" -d "${SERVER_DIR}/tf/addons/sourcemod/" \
   && mv "${CLASS_RESTRICT_PLUGIN_FILE_NAME}" "${SERVER_DIR}/tf/addons/sourcemod/plugins/${CLASS_RESTRICT_PLUGIN_FILE_NAME}" \
   && mv "${AFK_MANAGER_PLUGIN_FILE_NAME}" "${SERVER_DIR}/tf/addons/sourcemod/plugins/${AFK_MANAGER_PLUGIN_FILE_NAME}" \
   && mv "${AFK_MANAGER_PHRASES_FILE_NAME}" "${SERVER_DIR}/tf/addons/sourcemod/translations/${AFK_MANAGER_PHRASES_FILE_NAME}" \
   && tar xf "${SOURCEBANS_PLUGIN_FILE_NAME}" -C "${SERVER_DIR}/tf" \
   # clean everything up
-  && rm "${SOAP_DM_PLUGIN_FILE_NAME}" "${DHOOKS_PLUGIN_FILE_NAME}" "${COMP_FIXES_PLUGIN_FILE_NAME}" "${SOURCEBANS_PLUGIN_FILE_NAME}" \
+  && rm "${SOAP_DM_PLUGIN_FILE_NAME}" "${DHOOKS_PLUGIN_FILE_NAME}" "${COMP_FIXES_PLUGIN_FILE_NAME}" "${SOURCEBANS_PLUGIN_FILE_NAME}" "${TF2RUE_PLUGIN_FILE_NAME}" \
   && rm "checksum.md5" \
   # remove unused plugins
   && rm "${SERVER_DIR}/tf/addons/sourcemod/plugins/"{funcommands,funvotes}.smx

--- a/packages/tf2-dm/checksum.md5
+++ b/packages/tf2-dm/checksum.md5
@@ -5,3 +5,4 @@ cea0b0957a7ab1abf7e7f7bfd46d9d3e  classrestrict.smx
 b82f1184a9209e87251a03cfe9aa4221  soap.zip
 0f30773f5a981e03a68f9e4ddee70a89  sourcebans-pp-1.6.4.plugin-only.tar.gz
 21feb738cca02e44ba53b747d56ed4f9  tf2-comp-fixes.zip
+dc5ed138a53c9af951f120cf3e611a3d  tf2rue.zip


### PR DESCRIPTION
Since we removed TFTrue the check for tf_tournament_mode 1 is back, hence the whitelist is not getting applied. We need TFrue from Sappho to get this fixed.