### PR TITLE
feat(build): move to GitHub Packages registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - 'master'
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
   tf2-base:
     runs-on: ubuntu-latest
@@ -24,7 +27,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v4
         with:
-          images: melkortf/tf2-base
+          images: ${{ env.REGISTRY }}/melkortf/tf2-base
           tags: type=sha,format=long
       -
         name: Set up Docker Buildx
@@ -41,7 +44,7 @@ jobs:
           load: true
       -
         name: Save docker image
-        run: docker save melkortf/tf2-base:${{ steps.docker_meta.outputs.version }} | gzip > /tmp/tf2-base.tar.gz
+        run: docker save ${{ env.REGISTRY }}/melkortf/tf2-base:${{ steps.docker_meta.outputs.version }} | gzip > /tmp/tf2-base.tar.gz
       -
         name: Upload docker image
         uses: actions/upload-artifact@v3
@@ -70,7 +73,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v4
         with:
-          images: melkortf/tf2-sourcemod
+          images: ${{ env.REGISTRY }}/melkortf/tf2-sourcemod
           tags: type=sha,format=long
       - 
         name: Load tf2-base
@@ -92,7 +95,7 @@ jobs:
           platforms: linux/amd64
       -
         name: Save docker image
-        run: docker save melkortf/tf2-sourcemod:${{ steps.docker_meta.outputs.version }} | gzip > /tmp/tf2-sourcemod.tar.gz
+        run: docker save ${{ env.REGISTRY }}/melkortf/tf2-sourcemod:${{ steps.docker_meta.outputs.version }} | gzip > /tmp/tf2-sourcemod.tar.gz
       -
         name: Upload docker image
         uses: actions/upload-artifact@v3
@@ -119,7 +122,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v4
         with:
-          images: melkortf/tf2-mge
+          images: ${{ env.REGISTRY }}/melkortf/tf2-mge
           tags: type=sha,format=long
       - 
         name: Load tf2-sourcemod
@@ -141,7 +144,7 @@ jobs:
           platforms: linux/amd64
       -
         name: Save docker image
-        run: docker save melkortf/tf2-mge:${{ steps.docker_meta.outputs.version }} | gzip > /tmp/tf2-mge.tar.gz
+        run: docker save ${{ env.REGISTRY }}/melkortf/tf2-mge:${{ steps.docker_meta.outputs.version }} | gzip > /tmp/tf2-mge.tar.gz
       -
         name: Upload docker image
         uses: actions/upload-artifact@v3
@@ -168,7 +171,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v4
         with:
-          images: melkortf/tf2-competitive
+          images: ${{ env.REGISTRY }}/melkortf/tf2-competitive
           tags: type=sha,format=long
       - 
         name: Load tf2-sourcemod
@@ -190,7 +193,7 @@ jobs:
           platforms: linux/amd64
       -
         name: Save docker image
-        run: docker save melkortf/tf2-competitive:${{ steps.docker_meta.outputs.version }} | gzip > /tmp/tf2-competitive.tar.gz
+        run: docker save ${{ env.REGISTRY }}/melkortf/tf2-competitive:${{ steps.docker_meta.outputs.version }} | gzip > /tmp/tf2-competitive.tar.gz
       -
         name: Upload docker image
         uses: actions/upload-artifact@v3
@@ -217,7 +220,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v4
         with:
-          images: melkortf/tf2-dm
+          images: ${{ env.REGISTRY }}/melkortf/tf2-dm
           tags: type=sha,format=long
       - 
         name: Load tf2-sourcemod
@@ -239,7 +242,7 @@ jobs:
           platforms: linux/amd64
       -
         name: Save docker image
-        run: docker save melkortf/tf2-dm:${{ steps.docker_meta.outputs.version }} | gzip > /tmp/tf2-dm.tar.gz
+        run: docker save ${{ env.REGISTRY }}/melkortf/tf2-dm:${{ steps.docker_meta.outputs.version }} | gzip > /tmp/tf2-dm.tar.gz
       -
         name: Upload docker image
         uses: actions/upload-artifact@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*.*.*'
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
   tf2-base:
     runs-on: ubuntu-latest
@@ -19,7 +22,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v4
         with:
-          images: melkortf/tf2-base
+          images: ${{ env.REGISTRY }}/melkortf/tf2-base
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -28,8 +31,9 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build
@@ -54,7 +58,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v4
         with:
-          images: melkortf/tf2-sourcemod
+          images: ${{ env.REGISTRY }}/melkortf/tf2-sourcemod
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -63,8 +67,9 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build
@@ -89,7 +94,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v4
         with:
-          images: melkortf/tf2-competitive
+          images: ${{ env.REGISTRY }}/melkortf/tf2-competitive
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -98,8 +103,9 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build
@@ -124,7 +130,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v4
         with:
-          images: melkortf/tf2-mge
+          images: ${{ env.REGISTRY }}/melkortf/tf2-mge
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -133,8 +139,9 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build
@@ -159,7 +166,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v4
         with:
-          images: melkortf/tf2-dm
+          images: ${{ env.REGISTRY }}/melkortf/tf2-dm
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -168,8 +175,9 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build

--- a/packages/tf2-competitive/Dockerfile
+++ b/packages/tf2-competitive/Dockerfile
@@ -1,5 +1,6 @@
+ARG REGISTRY=ghcr.io
 ARG TF2_SOURCEMOD_TAG=latest
-FROM melkortf/tf2-sourcemod:${TF2_SOURCEMOD_TAG}
+FROM ${REGISTRY}/melkortf/tf2-sourcemod:${TF2_SOURCEMOD_TAG}
 LABEL maintainer="garrappachc@gmail.com"
 
 COPY checksum.md5 .

--- a/packages/tf2-dm/Dockerfile
+++ b/packages/tf2-dm/Dockerfile
@@ -1,5 +1,6 @@
+ARG REGISTRY=ghcr.io
 ARG TF2_SOURCEMOD_TAG=latest
-FROM melkortf/tf2-sourcemod:${TF2_SOURCEMOD_TAG}
+FROM ${REGISTRY}/melkortf/tf2-sourcemod:${TF2_SOURCEMOD_TAG}
 LABEL maintainer="garrappachc@gmail.com"
 
 COPY checksum.md5 .

--- a/packages/tf2-mge/Dockerfile
+++ b/packages/tf2-mge/Dockerfile
@@ -1,5 +1,6 @@
+ARG REGISTRY=ghcr.io
 ARG TF2_SOURCEMOD_TAG=latest
-FROM melkortf/tf2-sourcemod:${TF2_SOURCEMOD_TAG}
+FROM ${REGISTRY}/melkortf/tf2-sourcemod:${TF2_SOURCEMOD_TAG}
 LABEL maintainer="garrappachc@gmail.com"
 
 COPY checksum.md5 .

--- a/packages/tf2-sourcemod/Dockerfile
+++ b/packages/tf2-sourcemod/Dockerfile
@@ -1,5 +1,6 @@
+ARG REGISTRY=ghcr.io
 ARG TF2_BASE_TAG=latest
-FROM melkortf/tf2-base:${TF2_BASE_TAG}
+FROM ${REGISTRY}/melkortf/tf2-base:${TF2_BASE_TAG}
 LABEL maintainer="garrappachc@gmail.com"
 
 COPY checksum.md5 .


### PR DESCRIPTION
> Docker is sunsetting Free Team organizations

All images are therefore published to GitHub Packages from now on:

- `melkortf/tf2-base` -> `ghcr.io/melkortf/tf2-base`
- `melkortf/tf2-sourcemod` -> `ghcr.io/melkortf/tf2-sourcemod`
- `melkortf/tf2-competitive` -> `ghcr.io/melkortf/tf2-competitive`
- `melkortf/tf2-mge` -> `ghcr.io/melkortf/tf2-mge`
- `melkortf/tf2-dm` -> `ghcr.io/melkortf/tf2-dm`

BREAKING CHANGE: All images are moved to GitHub Packages registry (**ghcr.io**)