### PR TITLE
Update RGL resources to `v256`

### DIFF
--- a/packages/tf2-competitive/Dockerfile
+++ b/packages/tf2-competitive/Dockerfile
@@ -29,7 +29,7 @@ ARG ETF2L_CONFIGS_VERSION=1.0.16
 ARG ETF2L_CONFIGS_URL=https://github.com/ETF2L/gameserver-configs/releases/download/${ETF2L_CONFIGS_VERSION}/${ETF2L_CONFIGS_FILE_NAME}
 
 ARG RGL_CONFIGS_FILE_NAME=server-resources-updater.zip
-ARG RGL_CONFIGS_VERSION=v117
+ARG RGL_CONFIGS_VERSION=v256
 ARG RGL_CONFIGS_URL=https://github.com/RGLgg/server-resources-updater/releases/download/${RGL_CONFIGS_VERSION}/${RGL_CONFIGS_FILE_NAME}
 
 ARG DEMOS_TF_PLUGIN_FILE_NAME=demostf.smx
@@ -69,6 +69,10 @@ RUN \
   && unzip -q -o "${NEOCURL_PLUGIN_FILE_NAME}" -d "${SERVER_DIR}/tf/addons/sourcemod" \
   && unzip -q "${ETF2L_CONFIGS_FILE_NAME}" -d "${SERVER_DIR}/tf/cfg/" \
   && unzip -q "${RGL_CONFIGS_FILE_NAME}" "cfg/*.cfg" && mv "cfg/"* "${SERVER_DIR}/tf/cfg/" \
+  && unzip -q "${RGL_CONFIGS_FILE_NAME}" "addons/sourcemod/plugins/"{config_checker,rglqol}.smx && mv "addons/sourcemod/plugins/"* "${SERVER_DIR}/tf/addons/sourcemod/plugins/" \
+  && unzip -q "${RGL_CONFIGS_FILE_NAME}" "addons/sourcemod/scripting/"{config_checker,rglqol}.sp && mv "addons/sourcemod/scripting/"* "${SERVER_DIR}/tf/addons/sourcemod/scripting/" \
+  && unzip -q "${RGL_CONFIGS_FILE_NAME}" "addons/sourcemod/plugins/disabled/"{p4sstime,tf2Halftime,roundtimer_override}.smx && mv "addons/sourcemod/plugins/disabled/"* "${SERVER_DIR}/tf/addons/sourcemod/plugins/disabled" \
+  && unzip -q "${RGL_CONFIGS_FILE_NAME}" "addons/sourcemod/scripting/disabled/roundtimer_override.sp" && mv "addons/sourcemod/scripting/disabled/"* "${SERVER_DIR}/tf/addons/sourcemod/scripting/disabled" \
   && unzip -q "${IMPROVED_MATCH_TIMER_PLUGIN_FILE_NAME}" \
   && unzip -q -n "${MGEMOD_PLUGIN_FILE_NAME}" -d "${SERVER_DIR}/tf" \
   && mv "Improved-Match-Timer-main/addons/sourcemod/plugins/"*.smx "${SERVER_DIR}/tf/addons/sourcemod/plugins/" \

--- a/packages/tf2-competitive/checksum.md5
+++ b/packages/tf2-competitive/checksum.md5
@@ -2,7 +2,7 @@
 b1b12f3ff9dfc16db0f3e532eb213ef7  demostf.smx
 37ee9e1c38d040d855159496ec65a9e6  etf2l_configs.zip
 c99c94133bf7965f69a6b3c19d66a393  mge.zip
-f04d86ea2f7f97ff344bd25d77669b70  server-resources-updater.zip
+3516e55d4d6e31172b1ab681eaacf449  server-resources-updater.zip
 8503eed566317c676c6bd386c20db33c  soap.zip
 b300b5af86f8b1fceda4e8c52d1bc5e6  srctvplus.so
 5576370d65439a86f4a2ec4c892d4221  srctvplus.vdf


### PR DESCRIPTION
Now includes these plugins by default:
- `config_checker`
- `rglqol`

Additionally, it will include these disabled plugins:
- `p4sstime`
- `tf2Halftime`
- `roundtimer_override`

I have not included `improved_match_timer`, `pause`, and `tf2-comp-fixes`, as thsoe are already included by us as first-party plugins.

I have also not included `rglupdater` and `updater`, as the images should be thought of as to be static.