### PR TITLE
fix(tf2-dm): update tf2rue to version 0.0.11

### DIFF
--- a/packages/tf2-dm/Dockerfile
+++ b/packages/tf2-dm/Dockerfile
@@ -23,7 +23,7 @@ ARG SOURCEBANS_PLUGIN_FILE_NAME=sourcebans-pp-1.6.4.plugin-only.tar.gz
 ARG SOURCEBANS_PLUGIN_URL=https://github.com/sbpp/sourcebans-pp/releases/download/1.6.4/${SOURCEBANS_PLUGIN_FILE_NAME}
 
 ARG TF2RUE_PLUGIN_FILE_NAME=tf2rue.zip
-ARG TF2RUE_PLUGIN_VERSION=v0.0.9
+ARG TF2RUE_PLUGIN_VERSION=v0.0.11
 ARG TF2RUE_PLUGIN_URL=https://github.com/sapphonie/tf2rue/releases/download/${TF2RUE_PLUGIN_VERSION}/${TF2RUE_PLUGIN_FILE_NAME}
 
 RUN \

--- a/packages/tf2-dm/checksum.md5
+++ b/packages/tf2-dm/checksum.md5
@@ -3,4 +3,4 @@ cea0b0957a7ab1abf7e7f7bfd46d9d3e  classrestrict.smx
 d2ce504b4eee4768071862a2c5f6c687  soap.zip
 0f30773f5a981e03a68f9e4ddee70a89  sourcebans-pp-1.6.4.plugin-only.tar.gz
 72b7d18bb346b1b2afef17c18c5447f4  tf2-comp-fixes.zip
-5f71c5665d8532346aa5a58b4e6fc485  tf2rue.zip
+b3472e739f607db23e41bc1a6d36de1d  tf2rue.zip


### PR DESCRIPTION
The Dockerfile for `tf2-dm` is currently using version `0.0.9` of `tf2rue`, which is causing significant problems, such as failing to load any whitelist. While `tf2-comp` was updated to version `0.0.11`, `tf2-dm` missed this update. This PR resolves the issue by aligning `tf2-dm` with the updated version.