### PR TITLE
Revert "fix(tf2-competitive): remove fbtf.tf configs (#210)"

### DIFF
--- a/packages/tf2-competitive/Dockerfile
+++ b/packages/tf2-competitive/Dockerfile
@@ -32,6 +32,10 @@ ARG RGL_CONFIGS_FILE_NAME=server-resources-updater.zip
 ARG RGL_CONFIGS_VERSION=v256
 ARG RGL_CONFIGS_URL=https://github.com/RGLgg/server-resources-updater/releases/download/${RGL_CONFIGS_VERSION}/${RGL_CONFIGS_FILE_NAME}
 
+ARG FBTF_CONFIGS_VERSION=23
+ARG FBTF_CONFIGS_FILE_NAME=fbtf_cfg_s${FBTF_CONFIGS_VERSION}.zip
+ARG FBTF_CONFIGS_URL=https://fbtf.tf/uploads/cfgs/fbtf_cfg_s${FBTF_CONFIGS_VERSION}.zip
+
 ARG DEMOS_TF_PLUGIN_FILE_NAME=demostf.smx
 ARG DEMOS_TF_PLUGIN_URL=https://github.com/demostf/plugin/raw/master/${DEMOS_TF_PLUGIN_FILE_NAME}
 
@@ -57,7 +61,7 @@ ARG TF2RUE_PLUGIN_URL=https://github.com/sapphonie/tf2rue/releases/download/${TF
 RUN \
   # download all the plugins
   wget -nv "${SOAP_DM_PLUGIN_URL}" "${COMP_FIXES_PLUGIN_URL}" "${UPDATED_PAUSE_PLUGIN_URL}" "${NEOCURL_PLUGIN_URL}" \
-  "${ETF2L_CONFIGS_URL}" "${RGL_CONFIGS_URL}" "${DEMOS_TF_PLUGIN_URL}" "${SRCTV_PLUS_SO_URL}" "${SRCTV_PLUS_VDF_URL}" \
+  "${ETF2L_CONFIGS_URL}" "${RGL_CONFIGS_URL}" "${FBTF_CONFIGS_URL}" "${DEMOS_TF_PLUGIN_URL}" "${SRCTV_PLUS_SO_URL}" "${SRCTV_PLUS_VDF_URL}" \
   "${F2_SOURCEMOD_PLUGINS_URL}" "${TF2RUE_PLUGIN_URL}" "${MGEMOD_PLUGIN_URL}" \
   && wget -nv "${IMPROVED_MATCH_TIMER_PLUGIN_URL}" -O "${IMPROVED_MATCH_TIMER_PLUGIN_FILE_NAME}" \
   # verify md5 checksums
@@ -68,6 +72,7 @@ RUN \
   && unzip -q -o "${UPDATED_PAUSE_PLUGIN_FILE_NAME}" -d "${SERVER_DIR}/tf/" \
   && unzip -q -o "${NEOCURL_PLUGIN_FILE_NAME}" -d "${SERVER_DIR}/tf/addons/sourcemod" \
   && unzip -q "${ETF2L_CONFIGS_FILE_NAME}" -d "${SERVER_DIR}/tf/cfg/" \
+  && unzip -q -j "${FBTF_CONFIGS_FILE_NAME}" -d "${SERVER_DIR}/tf/cfg/" \
   && unzip -q "${RGL_CONFIGS_FILE_NAME}" "cfg/*.cfg" && mv "cfg/"* "${SERVER_DIR}/tf/cfg/" \
   && unzip -q "${RGL_CONFIGS_FILE_NAME}" "addons/sourcemod/plugins/"{config_checker,rglqol}.smx && mv "addons/sourcemod/plugins/"* "${SERVER_DIR}/tf/addons/sourcemod/plugins/" \
   && unzip -q "${RGL_CONFIGS_FILE_NAME}" "addons/sourcemod/scripting/"{config_checker,rglqol}.sp && mv "addons/sourcemod/scripting/"* "${SERVER_DIR}/tf/addons/sourcemod/scripting/" \
@@ -89,6 +94,7 @@ RUN \
   && rm "${MGEMOD_PLUGIN_FILE_NAME}" \
   && rm "${NEOCURL_PLUGIN_FILE_NAME}" \
   && rm "${ETF2L_CONFIGS_FILE_NAME}" \
+  && rm "${FBTF_CONFIGS_FILE_NAME}" \
   && rm -r "${RGL_CONFIGS_FILE_NAME}" "cfg" \
   && rm -r "${IMPROVED_MATCH_TIMER_PLUGIN_FILE_NAME}" "Improved-Match-Timer-main" \
   && rm "${F2_SOURCEMOD_PLUGINS_FILE_NAME}" "${TF2RUE_PLUGIN_FILE_NAME}" \

--- a/packages/tf2-competitive/checksum.md5
+++ b/packages/tf2-competitive/checksum.md5
@@ -11,3 +11,4 @@ c3dd9cf8b5bafbf406ddf62a62d8d120  tf2-comp-fixes.zip
 58b6f3313d03eb0e725d9bd4e496d3ee  Improved-Match-Timer-main.zip
 06b16708c0296255732a27a79977dd10  f2-sourcemod-plugins.zip
 b3472e739f607db23e41bc1a6d36de1d  tf2rue.zip
+24f9e79f3466a13aab60dc7ee4fa30f8  fbtf_cfg_s23.zip


### PR DESCRIPTION
This reverts commit ce080b59d584820d38a5f81a417fa46e464ef27c.

fbtf.tf had an outage, but it's back now. Re-adding the FBTF config files. Solves https://github.com/melkortf/tf2-servers/issues/209