### PR TITLE
ci: add scheduled scanner for GitHub-release plugin updates

### DIFF
--- a/.github/workflows/scan-plugin-updates.yml
+++ b/.github/workflows/scan-plugin-updates.yml
@@ -1,0 +1,136 @@
+name: Scan plugin updates
+
+# Scans the GitHub-release-based dependencies pinned in the package Dockerfiles
+# and opens a pull request whenever a newer upstream release is available.
+# Each package gets its own PR (branch update-deps/<id>), so re-runs update the
+# existing PR instead of opening duplicates.
+#
+# Only dependencies hosted as proper GitHub releases are handled here. Packages
+# that are pulled from a moving ref (raw/master, archive/refs/heads/main), from
+# a non-GitHub host (fbtf.tf), or that use bespoke versioning (Metamod:Source
+# and SourceMod snapshots, F2's date-based builds) are intentionally left out
+# and continue to be updated manually via update-package.yml.
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { id: comp_fixes,    name: "TF2 Competitive Fixes",        repo: "ldesgoui/tf2-comp-fixes",        prefix: "COMP_FIXES",    prerelease: false }
+          - { id: soap_dm,       name: "SOAP-TF2DM",                   repo: "sapphonie/SOAP-TF2DM",           prefix: "SOAP_DM",       prerelease: false }
+          - { id: mgemod,        name: "MGEMod",                       repo: "sapphonie/MGEMod",               prefix: "MGEMOD",        prerelease: false }
+          - { id: tf2rue,        name: "tf2rue",                       repo: "sapphonie/tf2rue",               prefix: "TF2RUE",        prerelease: false }
+          - { id: sourcebans,    name: "SourceBans++",                 repo: "sbpp/sourcebans-pp",             prefix: "SOURCEBANS",    prerelease: false }
+          - { id: neocurl,       name: "SM-neocurl-ext",               repo: "sapphonie/SM-neocurl-ext",       prefix: "NEOCURL",       prerelease: true  }
+          - { id: rgl_configs,   name: "RGL.gg gameserver configs",    repo: "RGLgg/server-resources-updater", prefix: "RGL_CONFIGS",   prerelease: false }
+          - { id: etf2l_configs, name: "ETF2L.org gameserver configs", repo: "ETF2L/gameserver-configs",       prefix: "ETF2L_CONFIGS", prerelease: false }
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Resolve latest version and update Dockerfiles
+        id: update
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PKG_ID: ${{ matrix.id }}
+          PKG_REPO: ${{ matrix.repo }}
+          PKG_PREFIX: ${{ matrix.prefix }}
+          PKG_PRERELEASE: ${{ matrix.prerelease }}
+        run: |
+          set -euo pipefail
+
+          files=$(grep -rlE "^ARG ${PKG_PREFIX}_VERSION=" packages/*/Dockerfile || true)
+          if [[ -z "$files" ]]; then
+            echo "::warning::No Dockerfiles reference ${PKG_PREFIX}_VERSION; skipping."
+            exit 0
+          fi
+
+          current=$(grep -hoP "^ARG ${PKG_PREFIX}_VERSION=\K.*" $files | head -n1 || true)
+
+          # releases/latest excludes pre-releases; packages pinned to a
+          # pre-release need the full release list instead.
+          if [[ "$PKG_PRERELEASE" == "true" ]]; then
+            latest_tag=$(gh api "repos/${PKG_REPO}/releases?per_page=1" --jq '.[0].tag_name // empty' 2>/dev/null || true)
+          else
+            latest_tag=$(gh api "repos/${PKG_REPO}/releases/latest" --jq '.tag_name // empty' 2>/dev/null || true)
+          fi
+
+          if [[ -z "$latest_tag" ]]; then
+            echo "::warning::Could not resolve latest release tag for ${PKG_REPO}; skipping."
+            exit 0
+          fi
+
+          # Preserve the existing convention: keep a leading "v" only if the
+          # currently pinned version already has one.
+          if [[ "$current" == v* ]]; then
+            target="$latest_tag"
+          else
+            target="${latest_tag#v}"
+          fi
+
+          echo "${PKG_ID}: current=${current} latest_tag=${latest_tag} target=${target}"
+
+          needs_update=false
+          for f in $files; do
+            cur=$(grep -oP "^ARG ${PKG_PREFIX}_VERSION=\K.*" "$f")
+            if [[ "$cur" != "$target" ]]; then
+              needs_update=true
+            fi
+          done
+
+          if [[ "$needs_update" != "true" ]]; then
+            echo "All Dockerfiles already pin ${target}; nothing to do."
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          for f in $files; do
+            sed -i "s/^ARG ${PKG_PREFIX}_VERSION=.*/ARG ${PKG_PREFIX}_VERSION=${target}/" "$f"
+
+            # Reconstruct the download URL by evaluating the package's ARG lines
+            # in file order (FILE_NAME/VERSION are defined before URL).
+            url=$(grep -E "^ARG ${PKG_PREFIX}_" "$f" \
+              | sed -E 's/^ARG[[:space:]]+([A-Z0-9_]+)=(.*)$/\1="\2"/' \
+              | { eval "$(cat)"; eval echo "\$${PKG_PREFIX}_URL"; })
+
+            echo "  ${f}: ${url}"
+            checksum=$(curl --fail --location --silent "$url" | sha256sum | awk '{print $1}')
+            if [[ -z "$checksum" ]]; then
+              echo "::error::Failed to download ${url} to compute checksum."
+              exit 1
+            fi
+            sed -i "s/^ARG ${PKG_PREFIX}_CHECKSUM=.*/ARG ${PKG_PREFIX}_CHECKSUM=${checksum}/" "$f"
+          done
+
+          {
+            echo "updated=true"
+            echo "target=${target}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create pull request
+        if: steps.update.outputs.updated == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.ACTIONS_PAT }}
+          sign-commits: true
+          commit-message: "fix(deps): update ${{ matrix.name }} to version ${{ steps.update.outputs.target }}"
+          title: "fix(deps): update ${{ matrix.name }} to version ${{ steps.update.outputs.target }}"
+          body: |
+            Automated dependency update.
+
+            Bumps [${{ matrix.name }}](https://github.com/${{ matrix.repo }}) to version `${{ steps.update.outputs.target }}` and refreshes the SHA256 checksum in every Dockerfile that pins it.
+          branch: update-deps/${{ matrix.id }}
+          delete-branch: true
+          reviewers: garrappachc


### PR DESCRIPTION
## What

Adds `.github/workflows/scan-plugin-updates.yml`: a scheduled (daily 06:00 UTC, plus manual `workflow_dispatch`) workflow that watches the **GitHub-release-based** plugin/config dependencies pinned in the package Dockerfiles and opens a PR whenever a newer upstream release is available.

This is the first slice of the "auto-update image dependencies" idea, scoped to the deps that are clean GitHub releases (the majority).

## How it works

A matrix job, one entry per package. For each:

1. Find every `packages/*/Dockerfile` that pins `ARG <PREFIX>_VERSION`.
2. Resolve the latest upstream release tag (`releases/latest`, or the full release list for packages pinned to a pre-release).
3. Preserve the existing leading-`v` convention (kept only if the current value already has one).
4. If outdated, rewrite the version in **every** Dockerfile that pins it and refresh each `..._CHECKSUM` by re-downloading the asset (URL reconstructed from the Dockerfile's own ARGs, same trick as `update-package.yml`).
5. Open one PR per package on a stable branch `update-deps/<id>`, so re-runs update the existing PR instead of spamming new ones. PRs are created with `ACTIONS_PAT` so CI (`build.yml`) runs on them.

## Coverage

Included (real GitHub releases): `comp_fixes`, `soap_dm`, `mgemod`, `tf2rue`, `sourcebans`, `neocurl` (pre-release), `rgl_configs`, `etf2l_configs`.

Intentionally **excluded** (left to the manual `update-package.yml`):
- Moving refs — `demos.tf`, `mapdownloader` (`raw/master`), `Improved-Match-Timer` (`heads/main`)
- Non-GitHub — `fbtf.tf` configs
- Bespoke versioning — Metamod:Source / SourceMod snapshots, F2's date-based builds
- Multi-asset / version-in-URL — `srctvplus`, `updated-pause` (no `_VERSION` ARG)

## Notes

- Validated the matrix against the live GitHub API and the URL-reconstruction (incl. version-in-filename `sourcebans` and multi-Dockerfile packages). At time of writing it would correctly bump comp_fixes→v1.18.1, soap_dm→4.4.8, mgemod→v3.0.9, tf2rue→v0.0.13, sourcebans→1.8.4, rgl_configs→v372, and no-op the already-current neocurl/etf2l.
- It also converges existing drift: `tf2-comp-fixes` is `1.16.14` in `tf2-dm` but `1.18.0` in `tf2-competitive` — the scanner would bring both to latest.
- Did **not** modify `update-package.yml` (its single-path design is wrong for multi-Dockerfile packages); this scanner is self-contained and additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)