### PR TITLE
feat: add tickrate selector and CSS tickrate binaries

### DIFF
--- a/packages/tf2-base/amd64.Dockerfile
+++ b/packages/tf2-base/amd64.Dockerfile
@@ -57,6 +57,11 @@ RUN envsubst < $HOME/tf2.txt.template > $HOME/tf2.txt \
   && mkdir $HOME/.steam \
   && ln -s $HOME/.local/share/Steam/steamcmd/linux64 $HOME/.steam/sdk64
 
+COPY css-tickrate-release-linux-x86_64.zip $HOME/
+RUN echo "8af9c47fa235f03baa7d418d7b69eec0c4e73f555549db441593696c197b69f1  $HOME/css-tickrate-release-linux-x86_64.zip" | sha256sum -c - \
+  && unzip -o $HOME/css-tickrate-release-linux-x86_64.zip -d ${SERVER_DIR}/tf \
+  && rm $HOME/css-tickrate-release-linux-x86_64.zip
+
 COPY server.cfg.template ${SERVER_DIR}/tf/cfg/server.cfg.template
 COPY --from=rcon-build /build/rcon/build/rcon ${SERVER_DIR}/rcon
 

--- a/packages/tf2-base/entrypoint.sh
+++ b/packages/tf2-base/entrypoint.sh
@@ -33,6 +33,35 @@ trap 'quit' SIGTERM
 
 auto_envsubst
 
+# --- Блок выбора TICKRATE ---
+TICKRATE_FLAGS=()
+if [ -n "${TICKRATE}" ]; then
+  case "${TICKRATE}" in
+    66)
+      echo "[Tickrate-Selector] Setting standard 66.7 Tickrate mode..."
+      TICKRATE_FLAGS=("-tickrate" "66" "+sv_maxupdaterate" "66" "+sv_minupdaterate" "66" "+sv_maxcmdrate" "66" "+sv_mincmdrate" "66")
+      ;;
+    100)
+      echo "[Tickrate-Selector] Setting High-Performance 100 Tickrate mode..."
+      TICKRATE_FLAGS=("-tickrate" "100" "+sv_maxupdaterate" "100" "+sv_minupdaterate" "100" "+sv_maxcmdrate" "100" "+sv_mincmdrate" "100")
+      ;;
+    133)
+      echo "[Tickrate-Selector] Setting Competitive 133 Tickrate mode..."
+      TICKRATE_FLAGS=("-tickrate" "133" "+sv_maxupdaterate" "133" "+sv_minupdaterate" "133" "+sv_maxcmdrate" "133" "+sv_mincmdrate" "133")
+      ;;
+    200)
+      echo "[Tickrate-Selector] WARNING: Setting EXTREME 200 Tickrate mode. Ensure CPU can handle this!"
+      TICKRATE_FLAGS=("-tickrate" "200" "+sv_maxupdaterate" "200" "+sv_minupdaterate" "200" "+sv_maxcmdrate" "200" "+sv_mincmdrate" "200")
+      ;;
+    *)
+      echo "[Tickrate-Selector] Unknown TICKRATE='${TICKRATE}'. Falling back to default engine settings."
+      ;;
+  esac
+else
+  echo "[Tickrate-Selector] TICKRATE variable is not set. Using default 66.7 tickrate."
+fi
+# ----------------------------
+
 # enablefakeip switch
 if [ "$ENABLE_FAKE_IP" = "1" ]; then
   FAKE_IP_FLAG="-enablefakeip"
@@ -40,10 +69,12 @@ else
   FAKE_IP_FLAG=""
 fi
 
+# Запуск сервера с внедрением динамического массива TICKRATE_FLAGS
 faketty $SERVER_DIR/$SRCDS_EXEC \
   -game tf \
   -secured \
   $FAKE_IP_FLAG \
+  "${TICKRATE_FLAGS[@]}" \
   -steam_dir ${HOME}/.steam/steamcmd \
   -steamcmd_script ${HOME}/tf2.txt \
   -autoupdate \

--- a/packages/tf2-base/i386.Dockerfile
+++ b/packages/tf2-base/i386.Dockerfile
@@ -62,6 +62,11 @@ RUN envsubst < $HOME/tf2.txt.template > $HOME/tf2.txt \
   && mkdir -p $HOME/.steam \
   && ln -s $HOME/.local/share/Steam/steamcmd/linux32 $HOME/.steam/sdk32
 
+COPY css-tickrate-release-linux-x86.zip $HOME/
+RUN echo "661145ad08af61ad0327586ed56e820e7f178665c92ffa95b8891cd1a3d38f7e  $HOME/css-tickrate-release-linux-x86.zip" | sha256sum -c - \
+  && unzip -o $HOME/css-tickrate-release-linux-x86.zip -d ${SERVER_DIR}/tf \
+  && rm $HOME/css-tickrate-release-linux-x86.zip
+
 COPY server.cfg.template ${SERVER_DIR}/tf/cfg/server.cfg.template
 COPY --from=rcon-build /build/rcon/build/rcon ${SERVER_DIR}/rcon
 
@@ -82,7 +87,7 @@ ENV STV_PASSWORD=
 ENV DOWNLOAD_URL="https://fastdl.serveme.tf/"
 
 WORKDIR $SERVER_DIR
-COPY entrypoint.sh .
+COPY --chmod=755 entrypoint.sh .
 COPY healthcheck.sh .
 
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
## Changes

- Add tickrate selector in entrypoint.sh supporting 66, 100, 133, and 200 tickrates
- Add CSS tickrate release binaries for both i386 and amd64 architectures
- Update Dockerfiles to copy and extract tickrate binaries
- Add --chmod=755 to entrypoint.sh COPY in i386.Dockerfile

## Usage

Set the `TICKRATE` environment variable to one of: 66, 100, 133, or 200. If not set, defaults to 66.7 tickrate.