### PR TITLE
fix(ci): assign instead of requesting review on dependency PRs

### DIFF
--- a/.github/workflows/scan-plugin-updates.yml
+++ b/.github/workflows/scan-plugin-updates.yml
@@ -133,4 +133,4 @@ jobs:
             Bumps [${{ matrix.name }}](https://github.com/${{ matrix.repo }}) to version `${{ steps.update.outputs.target }}` and refreshes the SHA256 checksum in every Dockerfile that pins it.
           branch: update-deps/${{ matrix.id }}
           delete-branch: true
-          reviewers: garrappachc
+          assignees: garrappachc


### PR DESCRIPTION
The scan-plugin-updates workflow creates dependency PRs with `ACTIONS_PAT`, making its owner the PR author. Requesting a review from the author fails with:

> Review cannot be requested from pull request author.

which failed the sourcebans scan job on 2026-07-09 even though the PR itself was created fine. Switch `reviewers:` to `assignees:`, which GitHub allows for the PR author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)