### PR TITLE
ci: scan source-tickrate for updates

### DIFF
--- a/.github/workflows/scan-plugin-updates.yml
+++ b/.github/workflows/scan-plugin-updates.yml
@@ -35,6 +35,7 @@ jobs:
           - { id: neocurl,       name: "SM-neocurl-ext",               repo: "sapphonie/SM-neocurl-ext",       prefix: "NEOCURL",       prerelease: true  }
           - { id: rgl_configs,   name: "RGL.gg gameserver configs",    repo: "RGLgg/server-resources-updater", prefix: "RGL_CONFIGS",   prerelease: false }
           - { id: etf2l_configs, name: "ETF2L.org gameserver configs", repo: "ETF2L/gameserver-configs",       prefix: "ETF2L_CONFIGS", prerelease: false }
+          - { id: tickrate,      name: "source-tickrate",              repo: "angelfor3v3r/source-tickrate",   prefix: "TICKRATE",      prerelease: false }
 
     steps:
       - name: Checkout
@@ -51,7 +52,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          files=$(grep -rlE "^ARG ${PKG_PREFIX}_VERSION=" packages/*/Dockerfile || true)
+          # *Dockerfile also matches tf2-base's arch-specific amd64/i386.Dockerfile
+          files=$(grep -rlE "^ARG ${PKG_PREFIX}_VERSION=" packages/*/*Dockerfile || true)
           if [[ -z "$files" ]]; then
             echo "::warning::No Dockerfiles reference ${PKG_PREFIX}_VERSION; skipping."
             exit 0


### PR DESCRIPTION
Adds the source-tickrate plugin (introduced in #280) to the daily plugin update scan.

- New matrix entry for `angelfor3v3r/source-tickrate` (prefix `TICKRATE`).
- Widens the Dockerfile glob from `packages/*/Dockerfile` to `packages/*/*Dockerfile`, since the plugin is pinned in tf2-base's `amd64.Dockerfile` and `i386.Dockerfile`, which the old glob missed.

Verified locally by replaying the workflow's discovery/URL/checksum steps: both Dockerfiles are found, the reconstructed release URLs are correct per arch, and the downloaded checksums match the pinned ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)