### PR TITLE
fix(tf2-base): copy entrypoint.sh with executable permissions

### DIFF
--- a/packages/tf2-base/amd64.Dockerfile
+++ b/packages/tf2-base/amd64.Dockerfile
@@ -85,7 +85,7 @@ ENV STV_PASSWORD=
 ENV DOWNLOAD_URL="https://fastdl.serveme.tf/"
 
 WORKDIR $SERVER_DIR
-COPY entrypoint.sh .
+COPY --chmod=755 entrypoint.sh .
 COPY healthcheck.sh .
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/packages/tf2-base/i386.Dockerfile
+++ b/packages/tf2-base/i386.Dockerfile
@@ -90,7 +90,7 @@ ENV STV_PASSWORD=
 ENV DOWNLOAD_URL="https://fastdl.serveme.tf/"
 
 WORKDIR $SERVER_DIR
-COPY entrypoint.sh .
+COPY --chmod=755 entrypoint.sh .
 COPY healthcheck.sh .
 
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
Related: #280, #283

`entrypoint.sh` lost its executable bit during #280's review iterations, breaking container startup. #283 tried to restore it, but the squash merge silently dropped the mode change — at the merge base the file was already 755, so from the squash's perspective the branch changed nothing, and master's 644 won.

Instead of relying on the git mode bit, set the permissions explicitly with `COPY --chmod=755` in both Dockerfiles (matching how `install_tf2.sh` is already handled), so this class of regression can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)