### PR TITLE
ci: smoke test tf2-base image on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -351,6 +351,28 @@ jobs:
           load: true
           tags: ghcr.io/melkortf/tf2-base/i386:pr
 
+      - name: Verify entrypoint is executable
+        run: docker run --rm --entrypoint /bin/bash ghcr.io/melkortf/tf2-base/i386:pr -c 'test -x "${SERVER_DIR}/entrypoint.sh"'
+
+      - name: Smoke test tf2-base (i386)
+        run: |
+          docker run --detach --name smoke-test ghcr.io/melkortf/tf2-base/i386:pr
+          for _ in $(seq 1 30); do
+            sleep 10
+            running=$(docker inspect --format '{{.State.Running}}' smoke-test)
+            health=$(docker inspect --format '{{.State.Health.Status}}' smoke-test)
+            echo "running=${running} health=${health}"
+            if [ "${health}" = "healthy" ]; then
+              docker rm --force smoke-test
+              exit 0
+            fi
+            if [ "${running}" != "true" ] || [ "${health}" = "unhealthy" ]; then
+              break
+            fi
+          done
+          docker logs smoke-test
+          exit 1
+
       - name: Build tf2-sourcemod (i386)
         uses: docker/build-push-action@v7
         with:


### PR DESCRIPTION
Follow-up to #284 (and the #280/#283 entrypoint saga).

`pr-validate` only proves the images *build* — the lost executable bit on `entrypoint.sh` was a runtime failure that CI could not see. This adds two checks to `pr-validate`, right after the `tf2-base` build:

1. **Exec-bit assertion** — instant guard against exactly the #280 regression class.
2. **Boot smoke test** — starts the container and polls Docker's health state until the built-in `healthcheck.sh` (a real `rcon status` probe) reports healthy, verifying the entrypoint runs, templating works, and srcds boots and answers RCON. Bails out early if the container dies or turns unhealthy, and dumps `docker logs` on failure. Capped at ~5 minutes; expected to pass in ~1–2.

The image boots with its default env (`RCON_PASSWORD=123456`), so no extra configuration is needed. Placed before the dependent image builds to fail fast on a broken base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)