### PR TITLE
ci: scan more plugins for updates

### DIFF
--- a/.github/workflows/scan-plugin-updates.yml
+++ b/.github/workflows/scan-plugin-updates.yml
@@ -8,8 +8,9 @@ name: Scan plugin updates
 # Only dependencies hosted as proper GitHub releases are handled here. Packages
 # that are pulled from a moving ref (raw/master, archive/refs/heads/main), from
 # a non-GitHub host (fbtf.tf), or that use bespoke versioning (Metamod:Source
-# and SourceMod snapshots, F2's date-based builds) are intentionally left out
-# and continue to be updated manually via update-package.yml.
+# and SourceMod snapshots, srctvplus' two asset/checksum pairs) are
+# intentionally left out and continue to be updated manually via
+# update-package.yml.
 
 on:
   schedule:
@@ -36,6 +37,10 @@ jobs:
           - { id: rgl_configs,   name: "RGL.gg gameserver configs",    repo: "RGLgg/server-resources-updater", prefix: "RGL_CONFIGS",   prerelease: false }
           - { id: etf2l_configs, name: "ETF2L.org gameserver configs", repo: "ETF2L/gameserver-configs",       prefix: "ETF2L_CONFIGS", prerelease: false }
           - { id: tickrate,      name: "source-tickrate",              repo: "angelfor3v3r/source-tickrate",   prefix: "TICKRATE",      prerelease: false }
+          - { id: f2_plugins,    name: "F2's sourcemod plugins",       repo: "F2/F2s-sourcemod-plugins",       prefix: "F2_SOURCEMOD_PLUGINS", prerelease: false }
+          - { id: sdr_plugin,    name: "sdr-plugin",                   repo: "Red-X1/sdr-plugin",              prefix: "SDR_PLUGIN",    prerelease: false }
+          - { id: ultitrio,      name: "Ultitrio gameserver configs",  repo: "CoolstuffTF2/Ultitrio",          prefix: "ULTITRIO_CONFIGS", prerelease: false }
+          - { id: updated_pause, name: "updated-pause-plugin",         repo: "l-Aad-l/updated-pause-plugin",   prefix: "UPDATED_PAUSE", prerelease: false }
 
     steps:
       - name: Checkout

--- a/packages/tf2-competitive/Dockerfile
+++ b/packages/tf2-competitive/Dockerfile
@@ -102,7 +102,8 @@ RUN unzip -q "${IMPROVED_MATCH_TIMER_FILE_NAME}" \
   && cp "Improved-Match-Timer-main/addons/sourcemod/scripting/"*.sp "${PLUGIN_INSTALL_DIR}/addons/sourcemod/scripting/"
 
 ARG UPDATED_PAUSE_FILE_NAME=updated-pause-plugin.zip
-ARG UPDATED_PAUSE_URL=https://github.com/l-Aad-l/updated-pause-plugin/releases/download/v1.4.2/${UPDATED_PAUSE_FILE_NAME}
+ARG UPDATED_PAUSE_VERSION=v1.4.2
+ARG UPDATED_PAUSE_URL=https://github.com/l-Aad-l/updated-pause-plugin/releases/download/${UPDATED_PAUSE_VERSION}/${UPDATED_PAUSE_FILE_NAME}
 ARG UPDATED_PAUSE_CHECKSUM=5fb97a7be0f1246c25ebd674fd87f755f2adca1021c53f4022a6e25f547ea134
 ADD --checksum=sha256:${UPDATED_PAUSE_CHECKSUM} ${UPDATED_PAUSE_URL} .
 RUN unzip -q -o "${UPDATED_PAUSE_FILE_NAME}" -d "${PLUGIN_INSTALL_DIR}/"


### PR DESCRIPTION
Adds four more dependencies to the daily `scan-plugin-updates.yml` matrix, all verified to publish proper GitHub releases with stable download URLs:

- **F2's sourcemod plugins** — previously excluded as "date-based builds", but the scan only compares tags for inequality, so the date-based tags work fine. We're currently behind (`20260523` pinned, `20260702` upstream).
- **sdr-plugin** — already had a `SDR_PLUGIN_VERSION` ARG; was just never added to the matrix.
- **Ultitrio gameserver configs** — publishes releases; the tag-archive URL reconstructs correctly from the ARG lines.
- **updated-pause-plugin** — the version was hardcoded inline in the URL, so this extracts an `UPDATED_PAUSE_VERSION` ARG first. Upstream is at v1.6.2 vs our pinned v1.4.2, so the first scan run will pick that up.

Once merged, the scan will open the pending F2 and updated-pause bump PRs on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)