### PR TITLE
fix(ci): resolve scan-plugin-updates failure on Ultitrio configs

### DIFF
--- a/.github/workflows/scan-plugin-updates.yml
+++ b/.github/workflows/scan-plugin-updates.yml
@@ -6,11 +6,11 @@ name: Scan plugin updates
 # existing PR instead of opening duplicates.
 #
 # Only dependencies hosted as proper GitHub releases are handled here. Packages
-# that are pulled from a moving ref (raw/master, archive/refs/heads/main), from
-# a non-GitHub host (fbtf.tf), or that use bespoke versioning (Metamod:Source
-# and SourceMod snapshots, srctvplus' two asset/checksum pairs) are
-# intentionally left out and continue to be updated manually via
-# update-package.yml.
+# that are pulled from a moving ref (raw/master, archive/refs/heads/main,
+# Ultitrio's rolling MainRelease tag), from a non-GitHub host (fbtf.tf), or that
+# use bespoke versioning (Metamod:Source and SourceMod snapshots, srctvplus' two
+# asset/checksum pairs) are intentionally left out and continue to be updated
+# manually via update-package.yml.
 
 on:
   schedule:
@@ -39,7 +39,6 @@ jobs:
           - { id: tickrate,      name: "source-tickrate",              repo: "angelfor3v3r/source-tickrate",   prefix: "TICKRATE",      prerelease: false }
           - { id: f2_plugins,    name: "F2's sourcemod plugins",       repo: "F2/F2s-sourcemod-plugins",       prefix: "F2_SOURCEMOD_PLUGINS", prerelease: false }
           - { id: sdr_plugin,    name: "sdr-plugin",                   repo: "Red-X1/sdr-plugin",              prefix: "SDR_PLUGIN",    prerelease: false }
-          - { id: ultitrio,      name: "Ultitrio gameserver configs",  repo: "CoolstuffTF2/Ultitrio",          prefix: "ULTITRIO_CONFIGS", prerelease: false }
           - { id: updated_pause, name: "updated-pause-plugin",         repo: "l-Aad-l/updated-pause-plugin",   prefix: "UPDATED_PAUSE", prerelease: false }
 
     steps:

--- a/.github/workflows/update-package.yml
+++ b/.github/workflows/update-package.yml
@@ -12,6 +12,7 @@ on:
           - etf2l_configs
           - f2_sourcemod_plugins
           - tf2_comp_fixes
+          - ultitrio_configs
 
       version:
         type: string
@@ -54,6 +55,11 @@ jobs:
               echo "packageName=TF2 Competitive Fixes" >> "$GITHUB_OUTPUT"
               echo "packagePath=packages/tf2-competitive" >> "$GITHUB_OUTPUT"
               echo "variablePrefix=COMP_FIXES" >> "$GITHUB_OUTPUT"
+              ;;
+            ultitrio_configs)
+              echo "packageName=Ultitrio gameserver configs" >> "$GITHUB_OUTPUT"
+              echo "packagePath=packages/tf2-competitive" >> "$GITHUB_OUTPUT"
+              echo "variablePrefix=ULTITRIO_CONFIGS" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "invalid package"

--- a/packages/tf2-competitive/Dockerfile
+++ b/packages/tf2-competitive/Dockerfile
@@ -72,10 +72,10 @@ RUN unzip -q "${RGL_CONFIGS_FILE_NAME}" \
   && mkdir "${PLUGIN_INSTALL_DIR}/addons/sourcemod/scripting/disabled" \
   && cp "addons/sourcemod/scripting/disabled/roundtimer_override.sp" "${PLUGIN_INSTALL_DIR}/addons/sourcemod/scripting/disabled/"
 
-ARG ULTITRIO_CONFIGS_VERSION=3.2.1
+ARG ULTITRIO_CONFIGS_VERSION=MainRelease
 ARG ULTITRIO_CONFIGS_FILE_NAME=Ultitrio-${ULTITRIO_CONFIGS_VERSION}.zip
-ARG ULTITRIO_CONFIGS_URL=https://github.com/CoolstuffTF2/Ultitrio/archive/refs/tags/v${ULTITRIO_CONFIGS_VERSION}.zip
-ARG ULTITRIO_CONFIGS_CHECKSUM=73c5a7daca365bc8e5461e49bd42430aec482c0e5d9e155651cbb54cd18e1a29
+ARG ULTITRIO_CONFIGS_URL=https://github.com/CoolstuffTF2/Ultitrio/archive/refs/tags/${ULTITRIO_CONFIGS_VERSION}.zip
+ARG ULTITRIO_CONFIGS_CHECKSUM=f3aa0b47ad16492d401966dab3e82ce0a967e49348d0a5e527e8d4635f7ecc3b
 ADD --checksum=sha256:${ULTITRIO_CONFIGS_CHECKSUM} ${ULTITRIO_CONFIGS_URL} ./${ULTITRIO_CONFIGS_FILE_NAME}
 RUN unzip -q "${ULTITRIO_CONFIGS_FILE_NAME}" \
   && cp "Ultitrio-${ULTITRIO_CONFIGS_VERSION}/ultitrio_"*.{cfg,txt} "${PLUGIN_INSTALL_DIR}/cfg/"


### PR DESCRIPTION
The `scan-plugin-updates` workflow was failing on the Ultitrio job.

## Why

Upstream [CoolstuffTF2/Ultitrio](https://github.com/CoolstuffTF2/Ultitrio) switched its latest release to a **rolling `MainRelease` tag** (no per-version git tag anymore — the newest content, "Ultitrio v3.2.2", lives under `MainRelease`). The scan workflow resolves that tag and builds a `archive/refs/tags/vMainRelease.zip` URL, which 404s and fails the `curl --fail` checksum step. A moving tag can't be tracked by that scheme.

## What

- **`scan-plugin-updates.yml`**: drop Ultitrio from the matrix (it now falls under the documented "moving ref" exclusion; noted in the header comment).
- **`update-package.yml`**: add `ultitrio_configs` as a manual update option so it can still be bumped by hand.
- **`Dockerfile`**: rework the Ultitrio ARGs to the version-as-literal-tag scheme (drop the hardcoded `v` prefix) so the generic manual-update URL reconstruction works, and refresh version/checksum to the current `MainRelease` archive (also picks up the v3.2.2 content that was stuck behind the rolling tag).

Verified the manual-update URL reconstruction resolves to `.../tags/MainRelease.zip` with a checksum matching the Dockerfile pin, so builds and the manual workflow both succeed.