### PR TITLE
refactor: extract dependency-pinning into a single module

### DIFF
--- a/.github/workflows/scan-plugin-updates.yml
+++ b/.github/workflows/scan-plugin-updates.yml
@@ -63,8 +63,6 @@ jobs:
             exit 0
           fi
 
-          current=$(grep -hoP "^ARG ${PKG_PREFIX}_VERSION=\K.*" $files | head -n1 || true)
-
           # releases/latest excludes pre-releases; packages pinned to a
           # pre-release need the full release list instead.
           if [[ "$PKG_PRERELEASE" == "true" ]]; then
@@ -78,47 +76,32 @@ jobs:
             exit 0
           fi
 
-          # Preserve the existing convention: keep a leading "v" only if the
-          # currently pinned version already has one.
-          if [[ "$current" == v* ]]; then
-            target="$latest_tag"
-          else
-            target="${latest_tag#v}"
-          fi
+          echo "${PKG_ID}: latest_tag=${latest_tag}"
 
-          echo "${PKG_ID}: current=${current} latest_tag=${latest_tag} target=${target}"
-
-          needs_update=false
+          # pin-dependency.sh normalizes the tag, reconstructs the URL(s),
+          # refreshes the checksum(s), and reports 0=changed / 10=unchanged.
+          updated=false
           for f in $files; do
-            cur=$(grep -oP "^ARG ${PKG_PREFIX}_VERSION=\K.*" "$f")
-            if [[ "$cur" != "$target" ]]; then
-              needs_update=true
-            fi
+            set +e
+            ./scripts/pin-dependency.sh "$f" "$PKG_PREFIX" "$latest_tag"
+            code=$?
+            set -e
+            case "$code" in
+              0) updated=true ;;
+              10) ;;
+              *) echo "::error::pin-dependency.sh failed for ${f} (exit ${code})"; exit 1 ;;
+            esac
           done
 
-          if [[ "$needs_update" != "true" ]]; then
-            echo "All Dockerfiles already pin ${target}; nothing to do."
+          if [[ "$updated" != "true" ]]; then
+            echo "All Dockerfiles already pin the latest ${PKG_PREFIX}; nothing to do."
             echo "updated=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          for f in $files; do
-            sed -i "s/^ARG ${PKG_PREFIX}_VERSION=.*/ARG ${PKG_PREFIX}_VERSION=${target}/" "$f"
-
-            # Reconstruct the download URL by evaluating the package's ARG lines
-            # in file order (FILE_NAME/VERSION are defined before URL).
-            url=$(grep -E "^ARG ${PKG_PREFIX}_" "$f" \
-              | sed -E 's/^ARG[[:space:]]+([A-Z0-9_]+)=(.*)$/\1="\2"/' \
-              | { eval "$(cat)"; eval echo "\$${PKG_PREFIX}_URL"; })
-
-            echo "  ${f}: ${url}"
-            checksum=$(curl --fail --location --silent "$url" | sha256sum | awk '{print $1}')
-            if [[ -z "$checksum" ]]; then
-              echo "::error::Failed to download ${url} to compute checksum."
-              exit 1
-            fi
-            sed -i "s/^ARG ${PKG_PREFIX}_CHECKSUM=.*/ARG ${PKG_PREFIX}_CHECKSUM=${checksum}/" "$f"
-          done
+          # Read the normalized version back from a file for the PR message.
+          first=$(echo "$files" | head -n1)
+          target=$(sed -n "s|^ARG ${PKG_PREFIX}_VERSION=\(.*\)|\1|p" "$first" | head -n1)
 
           {
             echo "updated=true"

--- a/.github/workflows/update-package.yml
+++ b/.github/workflows/update-package.yml
@@ -67,38 +67,9 @@ jobs:
               ;;
           esac
   
-  generate-checksum:
-    runs-on: ubuntu-latest
-    needs: resolve-package-variables
-    outputs:
-      packageUrl: ${{ steps.generate-checksum.outputs.packageUrl }}
-      packageChecksum: ${{ steps.generate-checksum.outputs.packageChecksum }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - id: generate-checksum
-        name: Generate checksum
-        env:
-          PACKAGE_PATH: ${{ needs.resolve-package-variables.outputs.packagePath }}
-          PACKAGE_VERSION: ${{ inputs.version }}
-          VARIABLE_PREFIX: ${{ needs.resolve-package-variables.outputs.variablePrefix }}
-        run: |
-          set -o pipefail
-          sed -i "s/${VARIABLE_PREFIX}_VERSION=.*/${VARIABLE_PREFIX}_VERSION=${PACKAGE_VERSION}/" ${PACKAGE_PATH}/Dockerfile
-          if grep -q "${VARIABLE_PREFIX}_RELEASE_TAG=" ${PACKAGE_PATH}/Dockerfile; then
-            RELEASE_TAG="${PACKAGE_VERSION/-git/.}"
-            sed -i "s/${VARIABLE_PREFIX}_RELEASE_TAG=.*/${VARIABLE_PREFIX}_RELEASE_TAG=${RELEASE_TAG}/" ${PACKAGE_PATH}/Dockerfile
-          fi
-          PACKAGE_URL=$(grep -r "ARG ${VARIABLE_PREFIX}" ${PACKAGE_PATH}/Dockerfile | sed -E 's/^ARG\s(.+)=(.+)$/\1="\2"/g' | { eval "$(cat -)"; eval echo \$${VARIABLE_PREFIX}_URL; })
-          PACKAGE_CHECKSUM=$(curl --fail --location --silent "$PACKAGE_URL" | sha256sum | awk '{print $1}')
-          echo "packageUrl=$PACKAGE_URL" >> "$GITHUB_OUTPUT"
-          echo "packageChecksum=$PACKAGE_CHECKSUM" >> "$GITHUB_OUTPUT"
-
   update-version:
     runs-on: ubuntu-latest
-    needs: [resolve-package-variables, generate-checksum]
+    needs: resolve-package-variables
     permissions:
       contents: write
       pull-requests: write
@@ -107,29 +78,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Replace version and checksum
+      - id: pin
+        name: Pin version and checksum
         env:
           PACKAGE_PATH: ${{ needs.resolve-package-variables.outputs.packagePath }}
           PACKAGE_VERSION: ${{ inputs.version }}
-          PACKAGE_CHECKSUM: ${{ needs.generate-checksum.outputs.packageChecksum }}
           VARIABLE_PREFIX: ${{ needs.resolve-package-variables.outputs.variablePrefix }}
         run: |
-          sed -i "s/${VARIABLE_PREFIX}_VERSION=.*/${VARIABLE_PREFIX}_VERSION=${PACKAGE_VERSION}/" ${PACKAGE_PATH}/Dockerfile
-          sed -i "s/${VARIABLE_PREFIX}_CHECKSUM=.*/${VARIABLE_PREFIX}_CHECKSUM=${PACKAGE_CHECKSUM}/" ${PACKAGE_PATH}/Dockerfile
-          if grep -q "${VARIABLE_PREFIX}_RELEASE_TAG=" ${PACKAGE_PATH}/Dockerfile; then
-            RELEASE_TAG="${PACKAGE_VERSION/-git/.}"
-            sed -i "s/${VARIABLE_PREFIX}_RELEASE_TAG=.*/${VARIABLE_PREFIX}_RELEASE_TAG=${RELEASE_TAG}/" ${PACKAGE_PATH}/Dockerfile
-          fi
-    
+          set +e
+          ./scripts/pin-dependency.sh "${PACKAGE_PATH}/Dockerfile" "$VARIABLE_PREFIX" "$PACKAGE_VERSION"
+          code=$?
+          set -e
+          case "$code" in
+            0) echo "changed=true" >> "$GITHUB_OUTPUT" ;;
+            10) echo "changed=false" >> "$GITHUB_OUTPUT"
+                echo "::notice::${VARIABLE_PREFIX} already pinned to ${PACKAGE_VERSION}; nothing to do." ;;
+            *) echo "::error::pin-dependency.sh failed (exit ${code})"; exit 1 ;;
+          esac
+
       - name: Create pull request
+        if: steps.pin.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "fix(deps): update ${{needs.resolve-package-variables.outputs.packageName}} to version ${{inputs.version}}"
           sign-commits: true
           title: "fix(deps): update ${{needs.resolve-package-variables.outputs.packageName}} to version ${{inputs.version}}"
           body: |
-            Update [${{needs.resolve-package-variables.outputs.packageName}}](${{needs.generate-checksum.outputs.packageUrl}}) to version ${{inputs.version}}
-            SHA256: ${{needs.generate-checksum.outputs.packageChecksum}}
+            Update ${{needs.resolve-package-variables.outputs.packageName}} to version ${{inputs.version}}
           branch: update-${{inputs.package}}-${{inputs.version}}
           delete-branch: true
           reviewers: garrappachc

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,32 @@
+# Domain glossary
+
+Names for the concepts this repo is built around. Keep terms here in sync with
+the code that uses them.
+
+## Dependency pin
+
+A single upstream artifact (a plugin, a config bundle, a shared library) frozen
+into a Dockerfile as a block of `ARG <PREFIX>_*` lines: `_VERSION`, `_FILE_NAME`,
+`_URL`, `_CHECKSUM`, and — for Metamod/SourceMod — a derived `_RELEASE_TAG`. The
+`<PREFIX>` is the pin's key; the `_URL` is reconstructed from the ARG chain so it
+tracks `_VERSION` automatically. Some pins carry more than one artifact under one
+version (e.g. `SRCTV_PLUS` has an SO and a VDF, each with its own `_CHECKSUM`).
+
+`scripts/pin-dependency.sh` is the one module that reads and rewrites a pin: hand
+it a Dockerfile, a `<PREFIX>`, and a target tag and it normalizes the version,
+reconstructs each URL, refreshes each checksum, and reports changed / unchanged.
+Resolving *which* version to pin, and opening a PR, live outside it.
+
+## Version resolution (the seam above pin-dependency)
+
+Deciding the target version a pin should move to. Two adapters over the same pin
+operation:
+
+- **scan** (`scan-plugin-updates.yml`): resolves the latest GitHub release
+  automatically, on a schedule, for pins hosted as proper GitHub releases.
+- **update-package** (`update-package.yml`): takes a human-supplied version, for
+  pins on moving refs, non-GitHub hosts, or bespoke versioning (Metamod/SourceMod
+  snapshots) that scan intentionally leaves alone.
+
+Both resolve a version, then call `pin-dependency.sh`, then open a PR only when it
+reports a change.

--- a/scripts/pin-dependency.sh
+++ b/scripts/pin-dependency.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# Pin a known upstream version of a dependency into a Dockerfile.
+#
+# Given a Dockerfile, the ARG prefix a dependency is pinned under, and a target
+# upstream tag, this rewrites the pinned version, reconstructs each download URL
+# from the ARG chain, downloads the asset(s), and rewrites every checksum. When
+# the dependency carries a derived <PREFIX>_RELEASE_TAG (Metamod/SourceMod), that
+# is updated too.
+#
+# Resolving *which* version to pin (a GitHub release, a human's input) and
+# opening a pull request are the caller's job; this only pins a version it is
+# handed. Portable across GNU (CI) and BSD/macOS coreutils.
+#
+# Usage:
+#   pin-dependency.sh <dockerfile> <PREFIX> <tag>
+#   pin-dependency.sh --dry-run <dockerfile> <PREFIX> <tag>
+#   pin-dependency.sh --help
+#
+# Exit codes:
+#   0   the Dockerfile was changed (or, with --dry-run, would change)
+#   10  nothing changed: the tag is already pinned and checksums still match
+#   1   usage error
+#   2   the prefix is not pinned in the given Dockerfile
+#   3   a download or checksum computation failed
+
+set -euo pipefail
+
+usage() {
+  sed -n '3,25p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+dry_run=false
+case "${1:-}" in
+  --help|-h) usage; exit 0 ;;
+  --dry-run) dry_run=true; shift ;;
+esac
+
+if [ "$#" -ne 3 ]; then
+  echo "error: expected <dockerfile> <PREFIX> <tag>" >&2
+  usage >&2
+  exit 1
+fi
+
+dockerfile=$1
+prefix=$2
+tag=$3
+
+if [ ! -f "$dockerfile" ]; then
+  echo "error: no such Dockerfile: $dockerfile" >&2
+  exit 1
+fi
+
+# --- portable helpers --------------------------------------------------------
+
+# get_arg <file> <NAME> -> prints the value of `ARG NAME=<value>` (first match)
+get_arg() {
+  sed -n "s|^ARG $2=\\(.*\\)|\\1|p" "$1" | head -n1
+}
+
+# set_arg <file> <NAME> <VALUE> -> rewrites `ARG NAME=...` in place (atomic)
+set_arg() {
+  local tmp
+  tmp=$(mktemp)
+  sed "s|^ARG $2=.*|ARG $2=$3|" "$1" > "$tmp"
+  mv "$tmp" "$1"
+}
+
+# has_arg <file> <NAME> -> succeeds if `ARG NAME=` is present
+has_arg() {
+  grep -q "^ARG $2=" "$1"
+}
+
+sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+# normalize <tag> <current> -> tag matching the file's leading-"v" convention
+normalize() {
+  local tag=$1 current=$2
+  if [ "${current#v}" != "$current" ]; then
+    case "$tag" in v*) printf '%s' "$tag" ;; *) printf 'v%s' "$tag" ;; esac
+  else
+    printf '%s' "${tag#v}"
+  fi
+}
+
+# reconstruct_urls <file> <prefix> -> prints "URL_ARG_NAME<TAB>resolved-url" lines.
+# Evaluates the prefix's ARG chain in file order so <PREFIX>_URL expands against
+# the already-updated <PREFIX>_VERSION. Inputs are our own first-party Dockerfiles.
+reconstruct_urls() {
+  local file=$1 prefix=$2 defs names
+  defs=$(sed -n "s|^ARG[[:space:]][[:space:]]*\\(${prefix}[A-Z0-9_]*\\)=\\(.*\\)|\\1=\"\\2\"|p" "$file")
+  names=$(sed -n "s|^ARG[[:space:]][[:space:]]*\\(${prefix}[A-Z0-9_]*_URL\\)=.*|\\1|p" "$file")
+  (
+    eval "$defs"
+    for n in $names; do
+      eval "printf '%s\\t%s\\n' \"$n\" \"\$$n\""
+    done
+  )
+}
+
+# --- pin ---------------------------------------------------------------------
+
+if ! has_arg "$dockerfile" "${prefix}_VERSION"; then
+  echo "error: ${prefix}_VERSION is not pinned in $dockerfile" >&2
+  exit 2
+fi
+
+current=$(get_arg "$dockerfile" "${prefix}_VERSION")
+target=$(normalize "$tag" "$current")
+
+work=$(mktemp)
+trap 'rm -f "$work"' EXIT
+cp "$dockerfile" "$work"
+
+set_arg "$work" "${prefix}_VERSION" "$target"
+if has_arg "$work" "${prefix}_RELEASE_TAG"; then
+  set_arg "$work" "${prefix}_RELEASE_TAG" "${target/-git/.}"
+fi
+
+while IFS=$(printf '\t') read -r url_arg url; do
+  [ -n "$url_arg" ] || continue
+  checksum_arg="${url_arg%_URL}_CHECKSUM"
+  asset=$(mktemp)
+  if ! curl --fail --location --silent "$url" --output "$asset"; then
+    echo "error: failed to download $url" >&2
+    rm -f "$asset"
+    exit 3
+  fi
+  checksum=$(sha256 "$asset")
+  rm -f "$asset"
+  if [ -z "$checksum" ]; then
+    echo "error: failed to compute checksum for $url" >&2
+    exit 3
+  fi
+  echo "  ${checksum_arg}=${checksum}  <- ${url}" >&2
+  set_arg "$work" "$checksum_arg" "$checksum"
+done <<EOF
+$(reconstruct_urls "$work" "$prefix")
+EOF
+
+if cmp -s "$work" "$dockerfile"; then
+  echo "unchanged: ${prefix} already pinned to ${target} in ${dockerfile}" >&2
+  exit 10
+fi
+
+if [ "$dry_run" = true ]; then
+  echo "would update ${prefix} -> ${target} in ${dockerfile}:" >&2
+  diff "$dockerfile" "$work" || true
+  exit 0
+fi
+
+cp "$work" "$dockerfile"
+echo "updated ${prefix} -> ${target} in ${dockerfile}" >&2
+exit 0


### PR DESCRIPTION
## Why

The reconstruct-URL → download → checksum → rewrite logic for pinned dependencies was pasted across `scan-plugin-updates.yml` (once) and `update-package.yml` (twice), and only executed inside GitHub Actions. This concentrates it into one module that can be run and verified locally.

## What

- **New `scripts/pin-dependency.sh`** — `pin-dependency.sh <dockerfile> <PREFIX> <tag>`. Normalizes the tag to the file's leading-`v` convention, reconstructs each `<PREFIX>_URL` from the ARG chain, downloads, refreshes every `<PREFIX>_*CHECKSUM`, and derives `_RELEASE_TAG` where present (Metamod/SourceMod). Portable across GNU (CI) and BSD/macOS. `--dry-run` and `--help`; exits `0` changed / `10` unchanged / `2` prefix-absent / `3` fetch-failure.
- **Both workflows now call it.** Version resolution (GitHub API vs. human input) and PR creation stay in the workflows; everything downstream of a decided version lives in the module. `update-package` collapses from three jobs to one and skips the PR when nothing changed.
- **`CONTEXT.md`** records the `dependency pin` concept and the version-resolution seam.

Net −76 lines across the two workflows.

## Verification

- `--dry-run` against 8 real dependencies at their current pins reports `unchanged` (v-less, v-prefixed, the two-asset `SRCTV_PLUS`, `RELEASE_TAG` deps, and multi-file `TICKRATE`) — exercises URL reconstruction + download + checksum against live assets.
- Change path (`SOURCEBANS 2.0.2→2.0.1`), download-failure, and prefix-absent paths all behave as specified; multi-file bump updates every Dockerfile pinning the prefix.
- The first scheduled `scan` run confirms in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)